### PR TITLE
POC for #15

### DIFF
--- a/resources/config/eloquent.xml
+++ b/resources/config/eloquent.xml
@@ -6,7 +6,6 @@
             class="WouterJ\EloquentBundle\EventListener\EloquentInitializer"
         >
             <argument type="service" id="wouterj_eloquent" />
-            <argument>%wouterj_eloquent.default_connection%</argument>
 
             <tag name="kernel.event_subscriber" />
         </service>

--- a/resources/config/events.xml
+++ b/resources/config/events.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" ?>
+<container xmlns="http://symfony.com/schema/dic/services">
+
+    <services>
+        <service id="wouterj_eloquent.event.illuminate_dispatcher_bridge_configurator" class="WouterJ\EloquentBundle\DependencyInjection\Configurator\IlluminateDispatcherBridgeConfigurator" />
+
+        <service id="wouterj_eloquent.event.illuminate_dispatcher_bridge" class="WouterJ\EloquentBundle\EventDispatcher\IlluminateDispatcherBridge">
+            <argument type="service" id="event_dispatcher" />
+            <configurator service="wouterj_eloquent.event.illuminate_dispatcher_bridge_configurator" method="configure" />
+        </service>
+    </services>
+</container>

--- a/src/DependencyInjection/Configurator/IlluminateDispatcherBridgeConfigurator.php
+++ b/src/DependencyInjection/Configurator/IlluminateDispatcherBridgeConfigurator.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the WouterJEloquentBundle package.
+ *
+ * (c) 2014 Wouter de Jong
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace WouterJ\EloquentBundle\DependencyInjection\Configurator;
+
+use WouterJ\EloquentBundle\EventDispatcher\IlluminateDispatcherBridge;
+use WouterJ\EloquentBundle\Model\FakeModel;
+
+/**
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+final class IlluminateDispatcherBridgeConfigurator
+{
+    public function configure(IlluminateDispatcherBridge $dispatcher)
+    {
+        FakeModel::setBridgeEventDispatcher($dispatcher);
+    }
+}

--- a/src/DependencyInjection/WouterJEloquentExtension.php
+++ b/src/DependencyInjection/WouterJEloquentExtension.php
@@ -11,7 +11,6 @@
 
 namespace WouterJ\EloquentBundle\DependencyInjection;
 
-use WouterJ\EloquentBundle\Facade\Facade;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -25,8 +24,6 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class WouterJEloquentExtension extends Extension
 {
-    private $capsuleEnabled = false;
-
     /**
      * {@inheritDoc}
      */
@@ -38,6 +35,7 @@ class WouterJEloquentExtension extends Extension
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../../resources/config'));
 
         $loader->load('migrations.xml');
+        $loader->load('events.xml');
 
         $this->loadCapsule($config, $container, $loader);
         $this->loadEloquent($config, $container, $loader);
@@ -57,7 +55,9 @@ class WouterJEloquentExtension extends Extension
             $capsuleDefinition->addMethodCall('addConnection', [$connection, $name]);
         }
 
-        $container->setParameter('wouterj_eloquent.default_connection', $config['default_connection']);
+        if ('default' !== $config['default_connection']) {
+            $container->getDefinition('wouterj_eloquent.database_manager')->addMethodCall('setDefaultConnection', [$config['default_connection']]);
+        }
     }
 
     protected function loadEloquent(array $config, ContainerBuilder $container, Loader\XmlFileLoader $loader)

--- a/src/Event/BootingModelEvent.php
+++ b/src/Event/BootingModelEvent.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the WouterJEloquentBundle package.
+ *
+ * (c) 2014 Wouter de Jong
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace WouterJ\EloquentBundle\Event;
+
+use Illuminate\Database\Eloquent\Model;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+final class BootingModelEvent extends Event
+{
+    private $model;
+
+    public function __construct(Model $model)
+    {
+        $this->model = $model;
+    }
+    
+    public function getModel()
+    {
+        return clone $this->model;
+    }
+    
+    public function __clone()
+    {
+        $this->model = clone $this->model;
+    }
+}

--- a/src/EventDispacther/IlluminateDispatcherBridge.php
+++ b/src/EventDispacther/IlluminateDispatcherBridge.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the WouterJEloquentBundle package.
+ *
+ * (c) 2014 Wouter de Jong
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace WouterJ\EloquentBundle\EventDispatcher;
+
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use WouterJ\EloquentBundle\Event\BootingModelEvent;
+
+/**
+ * Partial bridge to the Illuminate Event Dispatcher. It only implements the methods required for the booting of
+ * Eloquent Models.
+ *
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+final class IlluminateDispatcherBridge
+{
+    private $dispatcher;
+
+    public function __construct(EventDispatcherInterface $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    /**
+     * Fire an event until the first non-null response is returned.
+     *
+     * @param  string $event
+     * @param  array  $payload
+     *
+     * @return mixed
+     */
+    public function until($event, $payload = [])
+    {
+        if ('eloquent.booting' !== substr($event, 0, 16)) {
+            return;
+        }
+        
+        $this->dispatcher->dispatch('eloquent.booting', new BootingModelEvent($payload));
+    }
+
+    /**
+     * Fire an event and call the listeners.
+     *
+     * @param string|object $event
+     * @param mixed         $payload
+     * @param bool          $halt
+     *
+     * @return array|null
+     */
+    public function fire($event, $payload = [], $halt = false)
+    {
+        // Do nothing
+    }
+
+    public function __clone()
+    {
+        $this->dispatcher = clone $this->dispatcher;
+    }
+}

--- a/src/EventListener/EloquentInitializer.php
+++ b/src/EventListener/EloquentInitializer.php
@@ -26,7 +26,6 @@ class EloquentInitializer implements EventSubscriberInterface
     /** @var Capsule */
     private $capsule;
     private $run = false;
-    private $defaultConnection;
 
     /** {@inheritDoc} */
     public static function getSubscribedEvents()
@@ -37,10 +36,9 @@ class EloquentInitializer implements EventSubscriberInterface
         ];
     }
 
-    public function __construct(Capsule $capsule, $defaultConnection = 'default')
+    public function __construct(Capsule $capsule)
     {
         $this->capsule = $capsule;
-        $this->defaultConnection = $defaultConnection;
     }
 
     /**
@@ -49,10 +47,6 @@ class EloquentInitializer implements EventSubscriberInterface
     public function initialize()
     {
         $this->capsule->bootEloquent();
-
-        if ('default' !== $this->defaultConnection) {
-            $this->capsule->getDatabaseManager()->setDefaultConnection($this->defaultConnection);
-        }
     }
 
     public function initializeConsole()

--- a/src/Model/FakeModel.php
+++ b/src/Model/FakeModel.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the WouterJEloquentBundle package.
+ *
+ * (c) 2014 Wouter de Jong
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace WouterJ\EloquentBundle\Model;
+
+use Illuminate\Database\Eloquent\Model;
+use WouterJ\EloquentBundle\EventDispatcher\IlluminateDispatcherBridge;
+
+/**
+ * @author Théo FIDRY <theo.fidry@gmail.com>
+ */
+final class FakeModel extends Model
+{
+    public function __construct()
+    {
+        throw new \DomainException('FakeModel should not be instantiated.');
+    }
+    
+    public static function setBridgeEventDispatcher(IlluminateDispatcherBridge $dispatcher)
+    {
+        static::$dispatcher = $dispatcher;
+    }
+}


### PR DESCRIPTION
The idea is rather simple: instead of trying to boot manually Eloquent via a listener which won't work everywhere like for #15, the booting is left to the `Model`. Eloquent Model has a dispatcher statically accessible, the idea so is to create an event dispatcher which will be attached to `Model` via a configurator. The event dispatcher will then fire a booting event to which we can attach a listener to boot Eloquent if it is not already booted. That said, this will work only if the event dispatcher will be properly instantiated and not lazy instantiated, which is something I could not verify...

@WouterJ not sure if I can work much more on this one, but here's the idea.