### PR TITLE
Fix illuminate database version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 
     , "require": {
           "php": "^5.5|^7.0"
-        , "illuminate/database": "^5.2"
+        , "illuminate/database": "~5.2.0"
         , "symfony/dependency-injection": "^2.6|^3.0"
     }
     , "require-dev": {


### PR DESCRIPTION
Laravel and it's package are not semver, https://github.com/illuminate/database/commit/d9e2379375c6a5d7a8d2444113ab9017cefd98c0 is a good reminder as it means that this library is broken with illuminate/database 5.3+