### PR TITLE
Fix migrator

### DIFF
--- a/src/Migrations/Migrator.php
+++ b/src/Migrations/Migrator.php
@@ -45,7 +45,7 @@ class Migrator extends LaravelMigrator
         $migrations = [];
         /** @var SplFileInfo $file */
         foreach ($files as $file) {
-            $migrations[] = $file->getRealPath();
+            $migrations[str_replace('.php', '', $file->getBasename())] = $file->getRealPath();
         }
 
         return $migrations;


### PR DESCRIPTION
I'm surprise to see there is no bug failing, I didn't look much into it, but while updating https://github.com/theofidry/AliceDataFixtures I face an issue during the migration reset as it doesn't find the migrations to rollback. You can see [here](https://github.com/laravel/framework/blob/5.3/src/Illuminate/Database/Migrations/Migrator.php#L252) why: it assumes the array of files gotten will have the migration name as an index.