### PR TITLE
Fixes symfony2 issue with misinterpretation of @mixin

### DIFF
--- a/src/WouterJEloquentBundle.php
+++ b/src/WouterJEloquentBundle.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 use WouterJ\EloquentBundle\DependencyInjection\Compiler\AddCasterPass;
 use WouterJ\EloquentBundle\DependencyInjection\Compiler\ObserverPass;
 use WouterJ\EloquentBundle\Command;
+use Doctrine\Common\Annotations\AnnotationReader;
 
 /**
  * @final
@@ -60,6 +61,9 @@ class WouterJEloquentBundle extends Bundle
         if ($this->container->has('wouterj_eloquent.facade.initializer')) {
             $this->container->get('wouterj_eloquent.facade.initializer')->initialize();
         }
+        
+        //fixes compatibily symfony v2 issues with misinterpretation of the annotation @mixin within Eloquent's model
+        AnnotationReader::addGlobalIgnoredName('mixin');
     }
 
     public function getPath()

--- a/src/WouterJEloquentBundle.php
+++ b/src/WouterJEloquentBundle.php
@@ -62,7 +62,7 @@ class WouterJEloquentBundle extends Bundle
             $this->container->get('wouterj_eloquent.facade.initializer')->initialize();
         }
         
-        //fixes compatibily symfony v2 issues with misinterpretation of the annotation @mixin within Eloquent's model
+        //fixes compatibility symfony v2 issues with misinterpretation of the annotation @mixin within Eloquent's model
         AnnotationReader::addGlobalIgnoredName('mixin');
     }
 


### PR DESCRIPTION
Fixes compatibility symfony v2 issues with misinterpretation of the annotation `@mixin` within Eloquent's model base class