### PR TITLE
Adds port parameter to the configuration parsing

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -134,7 +134,7 @@ class Configuration implements ConfigurationInterface
                                 ->defaultValue('mysql')
                             ->end()
                             ->scalarNode('host')->defaultValue('localhost')->end()
-                            ->scalarNode('port')->defaultValue(NULL)->end()
+                            ->scalarNode('port')->defaultValue(null)->end()
                             ->scalarNode('database')->isRequired()->end()
                             ->scalarNode('username')->defaultValue('root')->end()
                             ->scalarNode('password')->defaultValue('')->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -79,11 +79,11 @@ class Configuration implements ConfigurationInterface
                 ->ifTrue(function ($v) {
                     return is_array($v)
                         && !array_key_exists('connections', $v) && !array_key_exists('connection', $v)
-                        && count($v) !== count(array_diff(array_keys($v), ['driver', 'host', 'database', 'username', 'password', 'charset', 'collation', 'prefix']));
+                        && count($v) !== count(array_diff(array_keys($v), ['driver', 'host', 'port', 'database', 'username', 'password', 'charset', 'collation', 'prefix']));
                 })
                 ->then(function ($v) {
                     // Key that should be rewritten to the connection config
-                    $includedKeys = ['driver', 'host', 'database', 'username', 'password', 'charset', 'collation', 'prefix'];
+                    $includedKeys = ['driver', 'host', 'port', 'database', 'username', 'password', 'charset', 'collation', 'prefix'];
                     $connection = [];
                     foreach ($v as $key => $value) {
                         if (in_array($key, $includedKeys)) {
@@ -134,6 +134,7 @@ class Configuration implements ConfigurationInterface
                                 ->defaultValue('mysql')
                             ->end()
                             ->scalarNode('host')->defaultValue('localhost')->end()
+                            ->scalarNode('port')->defaultValue('3306')->end()
                             ->scalarNode('database')->isRequired()->end()
                             ->scalarNode('username')->defaultValue('root')->end()
                             ->scalarNode('password')->defaultValue('')->end()

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -134,7 +134,7 @@ class Configuration implements ConfigurationInterface
                                 ->defaultValue('mysql')
                             ->end()
                             ->scalarNode('host')->defaultValue('localhost')->end()
-                            ->scalarNode('port')->defaultValue('3306')->end()
+                            ->scalarNode('port')->defaultValue(NULL)->end()
                             ->scalarNode('database')->isRequired()->end()
                             ->scalarNode('username')->defaultValue('root')->end()
                             ->scalarNode('password')->defaultValue('')->end()

--- a/tests/DependencyInjection/WouterJEloquentExtensionTest.php
+++ b/tests/DependencyInjection/WouterJEloquentExtensionTest.php
@@ -76,6 +76,7 @@ abstract class WouterJEloquentExtensionTest extends TestCase
             [[
                 'driver' => 'mysql',
                 'host' => 'localhost',
+                'port' => null,
                 'database' => 'db',
                 'username' => 'root',
                 'password' => null,
@@ -86,6 +87,7 @@ abstract class WouterJEloquentExtensionTest extends TestCase
             [[
                 'driver' => 'sqlite',
                 'host' => 'local',
+                'port' => null,
                 'database' => 'foo.db',
                 'username' => 'user',
                 'password' => 'pass',

--- a/tests/Fixtures/config/with_connections.php
+++ b/tests/Fixtures/config/with_connections.php
@@ -6,7 +6,7 @@ $container->loadFromExtension('wouterj_eloquent', [
         'connection_1' => [
             'driver' => 'sqlite',
             'host' => 'local',
-            'port' => NULL,
+            'port' => null,
             'database' => 'foo.db',
             'username' => 'user',
             'password' => 'pass',

--- a/tests/Fixtures/config/with_connections.php
+++ b/tests/Fixtures/config/with_connections.php
@@ -6,6 +6,7 @@ $container->loadFromExtension('wouterj_eloquent', [
         'connection_1' => [
             'driver' => 'sqlite',
             'host' => 'local',
+            'port' => NULL,
             'database' => 'foo.db',
             'username' => 'user',
             'password' => 'pass',

--- a/tests/Fixtures/config/with_connections.xml
+++ b/tests/Fixtures/config/with_connections.xml
@@ -7,6 +7,7 @@
         <connection name="connection_1"
             driver="sqlite"
             host="local"
+            port="null"
             database="foo.db"
             username="user"
             password="pass"

--- a/tests/Fixtures/config/with_connections.yml
+++ b/tests/Fixtures/config/with_connections.yml
@@ -6,6 +6,7 @@ wouterj_eloquent:
         connection_1:
             driver: sqlite
             host: local
+            port: ~
             database: foo.db
             username: user
             password: pass


### PR DESCRIPTION
Adds port parameter to the configuration parsing. No need for any further code modification since the eloquent capsule being created on \DependencyInjection\EloquentInitializer.php recognises the port param by default (in the configuration array that is passed in) :)