### PR TITLE
Fixing Seeder Command class naming convention

### DIFF
--- a/src/Command/SeederMakeCommand.php
+++ b/src/Command/SeederMakeCommand.php
@@ -62,7 +62,7 @@ class SeederMakeCommand extends Command
     {
         $lastPos = strrpos($name, '\\');
         $namespace = $lastPos ? substr($name, 0, $lastPos) : false;
-        $class = substr($name, $lastPos + 1);
+        $class = substr($name, $lastPos);
 
         $stub = file_get_contents($this->stubPath.'/seeder.stub');
         $stub = str_replace('DummyClass', $class, $stub);

--- a/src/Command/SeederMakeCommand.php
+++ b/src/Command/SeederMakeCommand.php
@@ -62,7 +62,7 @@ class SeederMakeCommand extends Command
     {
         $lastPos = strrpos($name, '\\');
         $namespace = $lastPos ? substr($name, 0, $lastPos) : false;
-        $class = substr($name, $lastPos);
+        $class = $lastPos ? substr($name, $lastPos + 1) : $name;
 
         $stub = file_get_contents($this->stubPath.'/seeder.stub');
         $stub = str_replace('DummyClass', $class, $stub);


### PR DESCRIPTION
This change is proposed to fix the bug reported in:
https://github.com/wouterj/WouterJEloquentBundle/issues/86