### PR TITLE
Corrected example of make:eloquent-migration.

### DIFF
--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -62,8 +62,8 @@ will be created by the migrations:
 
 .. code-block:: bash
 
-    $ php bin/console eloquent:migrate:make --create=flights create_flights_table
-    $ php bin/console eloquent:migrate:make --table=flights add_aircraft_to_flights_table
+    $ php bin/console make:eloquent-migration --create=flights create_flights_table
+    $ php bin/console make:eloquent-migration --table=flights add_aircraft_to_flights_table
 
 ======================  ==========================================================================================================
 Option                  Description


### PR DESCRIPTION
The make:eloquent-migration examples used a non existing format of eloquent:migration:make, perhaps an artefact of the past.
