### PR TITLE
fix: Query duration from Eloquent is in milliseconds

### DIFF
--- a/templates/data_collector/eloquent.html.twig
+++ b/templates/data_collector/eloquent.html.twig
@@ -67,7 +67,7 @@
             {% for query in collector.queries %}
                 <tr>
                     <td class="font-normal text-muted">{{ loop.index }}</td>
-                    <td>{{ '%0.2f'|format(query.time * 1000) }} ms</td>
+                    <td>{{ '%0.2f'|format(query.time) }} ms</td>
                     <td>
                         <span class="highlight">{{ query.sql|wouterj_format_sql }}</span><br>
 


### PR DESCRIPTION
**Laravel version**: any
**Symfony version**: any

This fixes a bug where query durations are reported incorrectly — times in milliseconds are displayed as if in seconds.

Query durations from the Eloquent `QueryExecuted` event are in milliseconds (and have always been: https://github.com/laravel/framework/blame/9.x/src/Illuminate/Database/Events/QueryExecuted.php#L22).

The template `templates/data_collector/eloquent.html.twig` assumes the time is in seconds. The change could have been made there instead. Just let me know if that should be the case.