### PR TITLE
Remove data-collector when no twig or profiler present

### DIFF
--- a/src/DependencyInjection/WouterJEloquentExtension.php
+++ b/src/DependencyInjection/WouterJEloquentExtension.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 use Symfony\Component\DependencyInjection\Reference;
 use Illuminate\Database\Events\QueryExecuted;
+use Twig\Extension\AbstractExtension;
 
 /**
  * @final
@@ -45,7 +46,7 @@ class WouterJEloquentExtension extends Extension
 
     protected function loadDataCollector(ContainerBuilder $container, Loader\XmlFileLoader $loader): void
     {
-        if (!($container->has('twig') && $container->has('profiler'))) {
+        if (!class_exists(\Twig_Environment::class) && !class_exists(AbstractExtension::class)) {
             return;
         }
 

--- a/src/DependencyInjection/WouterJEloquentExtension.php
+++ b/src/DependencyInjection/WouterJEloquentExtension.php
@@ -45,6 +45,10 @@ class WouterJEloquentExtension extends Extension
 
     protected function loadDataCollector(ContainerBuilder $container, Loader\XmlFileLoader $loader): void
     {
+        if (!($container->has('twig') && $container->has('profiler'))) {
+            return;
+        }
+
         $loader->load('data_collector.xml');
 
         $container->getDefinition('wouterj_eloquent.events')

--- a/tests/Functional/DataCollectorTest.php
+++ b/tests/Functional/DataCollectorTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WouterJ\EloquentBundle\Functional;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class DataCollectorTest extends KernelTestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return 'TestKernel';
+    }
+
+    public function testDataCollectorRegistered()
+    {
+        if (method_exists(__CLASS__, 'getContainer')) {
+            $container = self::getContainer();
+        } else {
+            static::bootKernel();
+            $container = self::$kernel->getContainer();
+        }
+
+        $this->assertArrayHasKey('wouterj_eloquent.data_collector', array_merge($container->getServiceIds(), $container->getRemovedIds()));
+    }
+}


### PR DESCRIPTION
**Laravel version**: 8.x
**Symfony version**: 5.0

Closes https://github.com/wouterj/WouterJEloquentBundle/issues/130