### PR TITLE
fix: use database input to prepareDatabase

### DIFF
--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -61,7 +61,11 @@ EOT
         ]);
 
         if ($input->getOption('seed')) {
-            $this->call($output, 'eloquent:seed', ['--force' => true]);
+            $this->call(
+                $output,
+                'eloquent:seed',
+                ['--force' => true] + ($input->getOption('database') ? ['--database' => $input->getOption('database')] : [])
+            );
         }
 
         return 0;
@@ -69,7 +73,7 @@ EOT
 
     private function prepareDatabase(InputInterface $input, OutputInterface $output): void
     {
-        if ($input->hasOption('database')) {
+        if ($input->getOption('database')) {
             $this->getMigrator()->setConnection($input->getOption('database'));
         }
         

--- a/src/Command/MigrateCommand.php
+++ b/src/Command/MigrateCommand.php
@@ -69,6 +69,10 @@ EOT
 
     private function prepareDatabase(InputInterface $input, OutputInterface $output): void
     {
+        if ($input->hasOption('database')) {
+            $this->getMigrator()->setConnection($input->getOption('database'));
+        }
+        
         if ($this->getMigrator()->repositoryExists()) {
             return;
         }


### PR DESCRIPTION
Fix bin/console eloquent:migrate:install --database=xxx

The prepareDatabase function checks whether the migrations table exists, but it always uses the default connection schema.

If the default schema does not have the migrations table, but the target schema (xxx) does, the command will try to create the table again and fails with:

`Base table or view already exists: 1050 Table 'migrations' already exists`

This fix sets the database connection before checking for the table existence, so the check is performed on the correct schema.